### PR TITLE
perf: close files explicitly when reading datasets

### DIFF
--- a/data/preprocess.py
+++ b/data/preprocess.py
@@ -14,7 +14,8 @@ python preprocess.py
 import random
 
 # read in all the names (32,032 names in total)
-names = open("names.txt", 'r').readlines()
+with open("names.txt", 'r') as file:
+    names = file.readlines()
 
 # get a permutation
 random.seed(42) # fix seed for reproducibility

--- a/mlp_pytorch.py
+++ b/mlp_pytorch.py
@@ -3,6 +3,7 @@ Implements a simple n-gram language model in PyTorch.
 Acts as the correctness reference for all the other versions.
 """
 import math
+
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
@@ -88,13 +89,22 @@ def eval_split(model, tokens, max_batches=None):
     return mean_loss
 
 # -----------------------------------------------------------------------------
+# simple function that tokenizes all characters in a file
+
+def tokenize_file(filename, char_to_token_mapping):
+    with open(filename, 'r') as file:
+        return [char_to_token_mapping[c] for c in file.read()]
+
+# -----------------------------------------------------------------------------
 # let's train!
 
 random = RNG(1337)
 # TODO: actually use this rng for the model initialization
 
 # "train" the Tokenizer, so we're able to map between characters and tokens
-train_text = open('data/train.txt', 'r').read()
+with open('data/train.txt', 'r') as file:
+    train_text = open('data/train.txt', 'r').read()
+
 assert all(c == '\n' or ('a' <= c <= 'z') for c in train_text)
 uchars = sorted(list(set(train_text))) # unique characters we see in the input
 vocab_size = len(uchars)
@@ -102,9 +112,9 @@ char_to_token = {c: i for i, c in enumerate(uchars)}
 token_to_char = {i: c for i, c in enumerate(uchars)}
 EOT_TOKEN = char_to_token['\n'] # designate \n as the delimiting <|endoftext|> token
 # pre-tokenize all the splits one time up here
-test_tokens = [char_to_token[c] for c in open('data/test.txt', 'r').read()]
-val_tokens = [char_to_token[c] for c in open('data/val.txt', 'r').read()]
-train_tokens = [char_to_token[c] for c in open('data/train.txt', 'r').read()]
+test_tokens = tokenize_file('data/test.txt', char_to_token)
+val_tokens = tokenize_file('data/val.txt', char_to_token)
+train_tokens = tokenize_file('data/train.txt', char_to_token)
 
 # create the model
 context_length = 3 # if 3 tokens predict the 4th, this is a 4-gram model


### PR DESCRIPTION
## Description
Use a Python context manager to open the dataset files so these files get closed properly. This makes the code more portable and also avoids relying on garbage collection.

I tested the code in `data/preprocess.py` and `mlp_pytorch.py` with Python 3.11.9 on macOS and with the following Python dependencies:
```
filelock==3.15.4
    # via torch
fsspec==2024.6.1
    # via torch
jinja2==3.1.4
    # via torch
markupsafe==2.1.5
    # via jinja2
mpmath==1.3.0
    # via sympy
networkx==3.3
    # via torch
numpy==2.0.0
sympy==1.13.0
    # via torch
torch==2.3.1
typing-extensions==4.12.2
    # via torch
```