### PR TITLE
perf: disable gradient computations during evaluation

### DIFF
--- a/mlp_pytorch.py
+++ b/mlp_pytorch.py
@@ -82,7 +82,8 @@ def eval_split(model, tokens, max_batches=None):
     data_iter = dataloader(tokens, context_length, batch_size)
     for _ in range(num_batches):
         inputs, targets = next(data_iter)
-        logits, loss = model(inputs, targets)
+        with torch.inference_mode():
+            logits, loss = model(inputs, targets)
         total_loss += loss.item()
     mean_loss = total_loss / num_batches
     return mean_loss


### PR DESCRIPTION
## Description
During model evaluation, even though `model.eval()` was turned on, this wasn't preventing the gradients from being computed, which is not necessary during evaluation.

Hence disable gradient computations during model evaluation using [`torch.inference_mode()`](https://pytorch.org/docs/stable/generated/torch.autograd.grad_mode.inference_mode.html), a context manager available since PyTorch version 1.9. This context manager is analogous to [`torch.no_grad()`](https://pytorch.org/docs/stable/generated/torch.no_grad.html) but gets better performance. For more details, see ['Inference Mode'](https://pytorch.org/docs/stable/notes/autograd.html#inference-mode) and [how this mode works under the hoods](https://pytorch.org/cppdocs/notes/inference_mode.html).

I tested the code in `mlp_pytorch.py` with Python 3.11.9 on macOS and with the following Python dependencies:
```
filelock==3.15.4
    # via torch
fsspec==2024.6.1
    # via torch
jinja2==3.1.4
    # via torch
markupsafe==2.1.5
    # via jinja2
mpmath==1.3.0
    # via sympy
networkx==3.3
    # via torch
numpy==2.0.0
sympy==1.13.0
    # via torch
torch==2.3.1
typing-extensions==4.12.2
    # via torch
```