### PR TITLE
Using the RNG to initialize model weights

### DIFF
--- a/common.py
+++ b/common.py
@@ -3,6 +3,7 @@
 # -----------------------------------------------------------------------------
 # random number generation
 
+import numpy as np
 # class that mimics the random interface in Python, fully deterministic,
 # and in a way that we also control fully, and can also use in C, etc.
 class RNG:
@@ -21,3 +22,10 @@ class RNG:
     def random(self):
         # random float32 in [0, 1)
         return (self.random_u32() >> 8) / 16777216.0
+
+    def random_array(self, m, n):
+        array = np.zeros((m, n), dtype=np.float32)
+        flat_array = array.ravel()
+        for i in range(m * n):
+            flat_array[i] = self.random()
+        return array

--- a/mlp_pytorch.py
+++ b/mlp_pytorch.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     # let's train!
 
     random = RNG(1337)
-    # TODO: actually use this rng for the model initialization
+    # DONE: actually using this rng for the model initialization
 
     # "train" the Tokenizer, so we're able to map between characters and tokens
     train_text = open('data/train.txt', 'r').read()

--- a/mlp_pytorch.py
+++ b/mlp_pytorch.py
@@ -87,59 +87,60 @@ def eval_split(model, tokens, max_batches=None):
     mean_loss = total_loss / num_batches
     return mean_loss
 
-# -----------------------------------------------------------------------------
-# let's train!
+if __name__ == "__main__":
+    # -----------------------------------------------------------------------------
+    # let's train!
 
-random = RNG(1337)
-# TODO: actually use this rng for the model initialization
+    random = RNG(1337)
+    # TODO: actually use this rng for the model initialization
 
-# "train" the Tokenizer, so we're able to map between characters and tokens
-train_text = open('data/train.txt', 'r').read()
-assert all(c == '\n' or ('a' <= c <= 'z') for c in train_text)
-uchars = sorted(list(set(train_text))) # unique characters we see in the input
-vocab_size = len(uchars)
-char_to_token = {c: i for i, c in enumerate(uchars)}
-token_to_char = {i: c for i, c in enumerate(uchars)}
-EOT_TOKEN = char_to_token['\n'] # designate \n as the delimiting <|endoftext|> token
-# pre-tokenize all the splits one time up here
-test_tokens = [char_to_token[c] for c in open('data/test.txt', 'r').read()]
-val_tokens = [char_to_token[c] for c in open('data/val.txt', 'r').read()]
-train_tokens = [char_to_token[c] for c in open('data/train.txt', 'r').read()]
+    # "train" the Tokenizer, so we're able to map between characters and tokens
+    train_text = open('data/train.txt', 'r').read()
+    assert all(c == '\n' or ('a' <= c <= 'z') for c in train_text)
+    uchars = sorted(list(set(train_text))) # unique characters we see in the input
+    vocab_size = len(uchars)
+    char_to_token = {c: i for i, c in enumerate(uchars)}
+    token_to_char = {i: c for i, c in enumerate(uchars)}
+    EOT_TOKEN = char_to_token['\n'] # designate \n as the delimiting <|endoftext|> token
+    # pre-tokenize all the splits one time up here
+    test_tokens = [char_to_token[c] for c in open('data/test.txt', 'r').read()]
+    val_tokens = [char_to_token[c] for c in open('data/val.txt', 'r').read()]
+    train_tokens = [char_to_token[c] for c in open('data/train.txt', 'r').read()]
 
-# create the model
-context_length = 3 # if 3 tokens predict the 4th, this is a 4-gram model
-embedding_size = 24
-hidden_size = 512
-model = MLP(vocab_size, context_length, embedding_size, hidden_size)
+    # create the model
+    context_length = 3 # if 3 tokens predict the 4th, this is a 4-gram model
+    embedding_size = 24
+    hidden_size = 512
+    model = MLP(vocab_size, context_length, embedding_size, hidden_size)
 
-# create the optimizer
-learning_rate = 1e-3
-optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
+    # create the optimizer
+    learning_rate = 1e-3
+    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
 
-# training loop
-batch_size = 64
-num_steps = 50000
-print(f'num_steps {num_steps}, num_epochs {num_steps * batch_size / len(train_tokens):.2f}')
-train_data_iter = dataloader(train_tokens, context_length, batch_size)
-for step in range(num_steps):
-    # cosine learning rate schedule, from max lr to 0
-    lr = learning_rate * 0.5 * (1 + math.cos(math.pi * step / num_steps))
-    for param_group in optimizer.param_groups:
-        param_group['lr'] = lr
-    # every now and then evaluate the validation loss
-    last_step = step == num_steps - 1
-    if step % 200 == 0 or last_step:
-        train_loss = eval_split(model, train_tokens, max_batches=20)
-        val_loss = eval_split(model, val_tokens)
-        print(f'step {step} | train_loss {train_loss:.4f} | val_loss {val_loss:.4f} | lr {lr:e}')
-    # ensure the model is in training mode
-    model.train()
-    # get the next batch of training data
-    inputs, targets = next(train_data_iter)
-    # forward through the model
-    logits, loss = model(inputs, targets)
-    # backpropagate and update the weights
-    loss.backward()
-    # step the optimizer
-    optimizer.step()
-    optimizer.zero_grad()
+    # training loop
+    batch_size = 64
+    num_steps = 50000
+    print(f'num_steps {num_steps}, num_epochs {num_steps * batch_size / len(train_tokens):.2f}')
+    train_data_iter = dataloader(train_tokens, context_length, batch_size)
+    for step in range(num_steps):
+        # cosine learning rate schedule, from max lr to 0
+        lr = learning_rate * 0.5 * (1 + math.cos(math.pi * step / num_steps))
+        for param_group in optimizer.param_groups:
+            param_group['lr'] = lr
+        # every now and then evaluate the validation loss
+        last_step = step == num_steps - 1
+        if step % 200 == 0 or last_step:
+            train_loss = eval_split(model, train_tokens, max_batches=20)
+            val_loss = eval_split(model, val_tokens)
+            print(f'step {step} | train_loss {train_loss:.4f} | val_loss {val_loss:.4f} | lr {lr:e}')
+        # ensure the model is in training mode
+        model.train()
+        # get the next batch of training data
+        inputs, targets = next(train_data_iter)
+        # forward through the model
+        logits, loss = model(inputs, targets)
+        # backpropagate and update the weights
+        loss.backward()
+        # step the optimizer
+        optimizer.step()
+        optimizer.zero_grad()


### PR DESCRIPTION
Adapting the included `random_u32` method in the `common.py` to initialize all the mlp weights.
Now the same method can be used for c implementation.
This now produces exact same losses across multiple runs, as desired:

```
num_steps 50000, num_epochs 14.97
step 0 | train_loss 8.7097 | val_loss 8.7871 | lr 1.000000e-03
step 200 | train_loss 2.8758 | val_loss 2.8733 | lr 9.999605e-04
step 400 | train_loss 2.8688 | val_loss 2.8716 | lr 9.998421e-04
step 600 | train_loss 2.8673 | val_loss 2.8743 | lr 9.996447e-04
step 800 | train_loss 2.8933 | val_loss 2.8776 | lr 9.993685e-04
```