### PR TITLE
update hparams

### DIFF
--- a/mlp_numpy.py
+++ b/mlp_numpy.py
@@ -222,18 +222,19 @@ train_tokens = [char_to_token[c] for c in open('data/train.txt', 'r').read()]
 
 # create the model
 context_length = 3 # if 3 tokens predict the 4th, this is a 4-gram model
-embedding_size = 48
-hidden_size = 512
+embedding_size = 256
+hidden_size = 1024
 init_rng = RNG(1337)
 model = MLP(init_rng, vocab_size, context_length, embedding_size, hidden_size)
 
 # optimizer
-learning_rate = 7e-4
-optimizer = AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
+learning_rate = 1e-4
+weight_decay = 1e-3
+optimizer = AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
 
 # training loop
 timer = StepTimer()
-batch_size = 128
+batch_size = 256
 num_steps = 50000
 print(f'num_steps {num_steps}, num_epochs {num_steps * batch_size / len(train_tokens):.2f}')
 train_data_iter = dataloader(train_tokens, context_length, batch_size)

--- a/mlp_pytorch.py
+++ b/mlp_pytorch.py
@@ -191,20 +191,21 @@ train_tokens = [char_to_token[c] for c in open('data/train.txt', 'r').read()]
 
 # create the model
 context_length = 3 # if 3 tokens predict the 4th, this is a 4-gram model
-embedding_size = 48
-hidden_size = 512
+embedding_size = 256
+hidden_size = 1024
 init_rng = RNG(1337)
 # these two classes both produce the exact same results. One uses nn.Module the other doesn't.
 model = MLPRaw(vocab_size, context_length, embedding_size, hidden_size, init_rng)
 # model = MLP(vocab_size, context_length, embedding_size, hidden_size, init_rng)
 
 # create the optimizer
-learning_rate = 7e-4
-optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=1e-4)
+learning_rate = 1e-4
+weight_decay = 1e-3
+optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
 
 # training loop
 timer = StepTimer()
-batch_size = 128
+batch_size = 256
 num_steps = 50000
 print(f'num_steps {num_steps}, num_epochs {num_steps * batch_size / len(train_tokens):.2f}')
 train_data_iter = dataloader(train_tokens, context_length, batch_size)


### PR DESCRIPTION
Contribution to TODO 
> tune the hyperparameters so they are not terrible, I just winged it. (currently seeing val loss 2.06, recall count-based 4-gram was 2.11)

These choices improve valid loss to ~2.05. Swept over {learning_rate, weight_decay, batch_size, embedding_size and hidden_size} and found this combination to work best. See below for a plot with the current baseline vs the new setup,
![image](https://github.com/user-attachments/assets/ed83c9f5-d091-4db3-a34d-eb2c5dbd23e4)

[Link to wandb workspace 
](https://wandb.ai/fcunig/mlp_pytorch/workspace?nw=nwuserfcunig)
PS. if desired I can also provide the few lines of code to plot to WandB in a separate PR